### PR TITLE
Add the option to show all users on assignment list instead of autocomplete

### DIFF
--- a/ckanext/issues/assets/js/list-users-assign-api.js
+++ b/ckanext/issues/assets/js/list-users-assign-api.js
@@ -42,7 +42,6 @@ ckan.module('list-users-assign-api', function (jQuery, _) {
     getUsers: function () {
       let users = []
       $.ajax('/api/3/action/organization_users?organization_id=' + this.options.organization_id).then((res) => {
-        console.log(this.el)
         users = res['result'].sort((a,b) => a.toLowerCase() >= b.toLowerCase())
         for (let user of users) {
           let userOpt = document.createElement('option')

--- a/ckanext/issues/assets/js/list-users-assign-api.js
+++ b/ckanext/issues/assets/js/list-users-assign-api.js
@@ -1,0 +1,56 @@
+"use strict";
+
+/* An auto-complete module for select and input elements that can pull in
+ * a list of terms from an API endpoint (provided using data-module-source).
+ *
+ * source   - A url pointing to an API autocomplete endpoint.
+ * interval - The interval between requests in milliseconds (default: 1000).
+ * items    - The max number of items to display (default: 10)
+ * tags     - Boolean attribute if true will create a tag input.
+ * key      - A string of the key you want to be the form value to end up on
+ *            from the ajax returned results
+ * label    - A string of the label you want to appear within the dropdown for
+ *            returned results
+ *
+ * Examples
+ *
+ *   // <input name="tags" data-module="autocomplete" data-module-source="http://" />
+ *
+ */
+
+ckan.module('list-users-assign-api', function (jQuery, _) {
+  return {
+    /* Options for the module */
+    options: {
+      organization_id: ''
+    },
+
+    /* Sets up the module, binding methods, creating elements etc. Called
+     * internally by ckan.module.initialize();
+     *
+     * Returns nothing.
+     */
+    initialize: function () {
+      jQuery.proxyAll(this, /_on/, /format/);
+      this.getUsers();
+    },
+
+    /* Sets up the auto complete plugin.
+     *
+     * Returns nothing.
+     */
+    getUsers: function () {
+      let users = []
+      $.ajax('/api/3/action/organization_users?organization_id=' + this.options.organization_id).then((res) => {
+        console.log(this.el)
+        users = res['result'].sort((a,b) => a.toLowerCase() >= b.toLowerCase())
+        for (let user of users) {
+          let userOpt = document.createElement('option')
+          userOpt.value = user['id']
+          userOpt.innerHTML = user['name']
+          this.el[0].appendChild(userOpt)
+        }
+      })
+    }
+  };
+});

--- a/ckanext/issues/assets/webassets.yml
+++ b/ckanext/issues/assets/webassets.yml
@@ -4,4 +4,20 @@ style:
   contents:
     - css/style.css
 
+modules/list-users-assign-api:
+  output: vendor/%(version)s_list-users-assign-api.js
+  contents:
+    - js/list-users-assign-api.js
+  extra:
+    preload:
+      - base/main
+
+modules/autocomplete-action-api:
+  output: vendor/%(version)s_autocomplete-action-api.js
+  contents:
+    - js/autocomplete-action-api.js
+  extra:
+    preload:
+      - base/main
+
 

--- a/ckanext/issues/lib/helpers.py
+++ b/ckanext/issues/lib/helpers.py
@@ -221,3 +221,6 @@ def issues_user_is_owner(user, dataset_id):
         authorized = False
 
     return authorized
+
+def use_autocomplete():
+    return config.get('ckanext.issues.use_autocomplete', True)

--- a/ckanext/issues/logic/action/__init__.py
+++ b/ckanext/issues/logic/action/__init__.py
@@ -11,5 +11,6 @@ from .action import (
     issue_comment_report_clear,
     issue_comment_search,
     issue_update,
+    organization_users,
     organization_users_autocomplete,
 )

--- a/ckanext/issues/logic/schema/schema.py
+++ b/ckanext/issues/logic/schema/schema.py
@@ -135,6 +135,12 @@ def issue_show_controller_schema():
     }
 
 
+def organization_users_schema():
+    return {
+        'organization_id': [not_missing],
+    }
+
+
 def organization_users_autocomplete_schema():
     return {
         'q': [not_missing],

--- a/ckanext/issues/plugin.py
+++ b/ckanext/issues/plugin.py
@@ -76,6 +76,8 @@ class IssuesPlugin(p.SingletonPlugin, DefaultTranslation):
                 helpers.issues_user_is_owner,
             'issues_users_who_reported_issue':
                 helpers.issues_users_who_reported_issue,
+            'use_autocomplete':
+                helpers.use_autocomplete
         }
 
     

--- a/ckanext/issues/templates/issues/show.html
+++ b/ckanext/issues/templates/issues/show.html
@@ -9,7 +9,11 @@ dataset - package object
 
 {% block styles %}
   {{ super() }}
-  {% asset 'gdx/modules/autocomplete-action-api' %}
+  {% if h.use_autocomplete() == True %}
+  {% asset 'issues/modules/autocomplete-action-api' %}
+  {% else %}
+  {% asset 'issues/modules/list-users-assign-api' %}
+  {% endif %}
 {% endblock %}
 
 {% block subtitle %}{{ '%s #%s - %s' % (issue.title, issue.number, _('Issues')) }} {% endblock %}
@@ -268,12 +272,18 @@ endfor %}">
     </h2>
     <form id='ckanext-issues-assign' class="dataset-form form-horizontal add-member-form" method='post' action="{{ h.url_for('issues.assign', issue_number=issue.number, dataset_id=dataset.id) }}">
         <div class="issues controls">
+          {% if h.use_autocomplete() == True %}
           <input id="assignee" type="text" name="assignee" placeholder="{{ _('Username') }}"
           value="" class="control-medium" data-module="autocomplete-action-api"
           {% if dataset['owner_org'] %}
           data-module-source="/api/3/action/organization_users_autocomplete?organization_id={{ dataset['owner_org']}}&q=?">
           {% else %}
           data-module-source="/api/3/action/user_autocomplete?q=?">
+          {% endif %}
+          {% else %}
+          <select id="assignee" name="assignee" class="form-control select-placeholder none-selected" data-module="list-users-assign-api" data-module-organization_id="{{dataset['owner_org']}}">
+            <option selected disabled hidden>Choose an user</option>
+          </select>
           {% endif %}
         </div>
         <div class="issues confirm">


### PR DESCRIPTION
If you add ckanext.issues.use_autocomplete = False, the page that shows an issue you have a select listing all the organization users instead of using an autocomplete.