### PR TITLE
Fix email body user

### DIFF
--- a/ckanext/issues/logic/action/action.py
+++ b/ckanext/issues/logic/action/action.py
@@ -4,9 +4,10 @@ from datetime import datetime
 
 from ckan import authz
 from ckan import model
-from ckan.lib import mailer, helpers
+from ckan.lib import helpers
 from ckan.logic import validate
 from ckan.plugins import toolkit
+from ckan.lib.mailer import mail_user, MailerException
 
 from ckanext.issues.exception import ReportAlreadyExists
 from ckanext.issues.lib.util import render_jinja2
@@ -150,8 +151,6 @@ def _get_issue_vars(issue, issue_subject, user_obj, recipient):
 
 def _get_issue_email_body(issue, issue_subject, user_obj, recipient):
     extra_vars = _get_issue_vars(issue, issue_subject, user_obj, recipient)
-    # Would use toolkit.render, but it mucks with response and other things,
-    # which is unnecessary, and toolkit.render_text uses genshi...
     return render_jinja2('issues/email/new_issue.html', extra_vars=extra_vars)
 
 
@@ -211,8 +210,8 @@ def issue_create(context, data_dict):
             body = _get_issue_email_body(issue, subject, user_obj, recipient)
             recipient_user = model.User.get(recipient['user_id'])
             try:
-                mailer.mail_user(recipient_user, subject, body)
-            except (mailer.MailerException, TypeError) as e:
+                mail_user(recipient_user, subject, body)
+            except (MailerException, TypeError) as e:
                 # TypeError occurs when we're running command from ckanapi
                 log.debug(e)
 
@@ -476,8 +475,8 @@ def issue_comment_create(context, data_dict):
                 issue_comment, subject, user_obj, recipient)
             recipient_user = model.User.get(recipient['user_id'])
             try:
-                mailer.mail_user(recipient_user, subject, body)
-            except (mailer.MailerException, TypeError) as e:
+                mail_user(recipient_user, subject, body)
+            except (MailerException, TypeError) as e:
                 # TypeError occurs when we're running command from ckanapi
                 log.debug(e)
 

--- a/ckanext/issues/logic/action/action.py
+++ b/ckanext/issues/logic/action/action.py
@@ -159,7 +159,10 @@ def _get_comment_email_body(comment, issue_subject, user_obj, recipient):
     extra_vars = _get_issue_vars(comment.issue, issue_subject, user_obj,
                                  recipient)
     extra_vars['comment'] = comment
-    return render_jinja2('issues/email/new_comment.html', extra_vars=extra_vars)
+    body = render_jinja2(
+        'issues/email/new_comment.html', extra_vars=extra_vars
+        )
+    return body
 
 
 @validate(schema.issue_create_schema)
@@ -204,14 +207,11 @@ def issue_create(context, data_dict):
         recipients = _get_recipients(context, dataset)
         subject = get_issue_subject(issue.as_dict())
 
-        for i, recipient in enumerate(recipients):
+        for recipient in recipients:
             body = _get_issue_email_body(issue, subject, user_obj, recipient)
-            user_obj = model.User.get(recipient['user_id'])
-            if i == 0:
-                log.debug('Mailing to %s (and %s others):\n%s',
-                          user_obj.email, len(recipients) - 1, body)
+            recipient_user = model.User.get(recipient['user_id'])
             try:
-                mailer.mail_user(user_obj, subject, body)
+                mailer.mail_user(recipient_user, subject, body)
             except (mailer.MailerException, TypeError) as e:
                 # TypeError occurs when we're running command from ckanapi
                 log.debug(e)
@@ -474,10 +474,9 @@ def issue_comment_create(context, data_dict):
         for recipient in recipients:
             body = _get_comment_email_body(
                 issue_comment, subject, user_obj, recipient)
-
-            user_obj = model.User.get(recipient['user_id'])
+            recipient_user = model.User.get(recipient['user_id'])
             try:
-                mailer.mail_user(user_obj, subject, body)
+                mailer.mail_user(recipient_user, subject, body)
             except (mailer.MailerException, TypeError) as e:
                 # TypeError occurs when we're running command from ckanapi
                 log.debug(e)

--- a/ckanext/issues/templates/issues/email/new_comment.html
+++ b/ckanext/issues/templates/issues/email/new_comment.html
@@ -1,13 +1,9 @@
---
-
-
-Problem: {{ h.url_for('issues.show_issue', dataset_id=dataset.name, issue_number=issue.number, qualified=True) }}
+---
+Issue: {{ h.url_for('issues.show_issue', dataset_id=dataset.name, issue_number=issue.number, qualified=True) }}
 Dataset: {{ h.url_for('dataset_read', id=dataset.name, qualified=True) }}
-
 ---
 
-
-A user '{{ user.fullname or user.name }}' has added a comment to one of your issues on {{ site_title }}.
+A user {{ user.fullname or user.name }} has added a comment to one of your issues on {{ site_title }}.
 
 The dataset is: {{ dataset.title }}
 The issue is: {{ issue_subject }}
@@ -20,8 +16,3 @@ In order to respond to the comment, please see the issue at: {{ h.url_for('issue
 Thank you,
 
 The {{ site_title }} team
-
---
-
-Issue: {{ h.url_for('issues.show_issue', dataset_id=dataset.name, issue_number=issue.number, qualified=True) }}
-Dataset: {{ h.url_for('dataset_read', id=dataset.name, qualified=True) }}

--- a/ckanext/issues/templates/issues/email/new_issue.html
+++ b/ckanext/issues/templates/issues/email/new_issue.html
@@ -1,16 +1,13 @@
+---
 Issue: {{ h.url_for('issues.show_issue', dataset_id=dataset.name, issue_number=issue.number, qualified=True) }}
 Dataset: {{ h.url_for('dataset_read', id=dataset.name, qualified=True) }}
-User: {{ user.fullname or user.name }}
-
 ---
 
-
-On {{ site_title }} a user has raised an issue with one of the datasets from organization '{{ recipient.organization_title }}', for which you are an {{ recipient.capacity }}.'
+A user {{ user.fullname or user.name }} has raised an issue with one of the datasets from organization '{{ recipient.organization_title }}', for which you are an {{ recipient.capacity }}.'
 
 The dataset is: {{ dataset.title }}
-The issue is:
+The issue is: {{ issue_subject }}
 
-> {{ issue_subject|wordwrap(width=76)|replace('\n', '\n> '|safe) }}
 > {{ issue.description|wordwrap(width=76)|replace('\n', '\n> '|safe) }}
 
 Please correct the problem or add an initial comment about the issue at: {{ h.url_for('issues.show_issue', dataset_id=dataset.name, issue_number=issue.number, qualified=True) }}. Once the issue has been resolved, click 'Close issue'.
@@ -18,9 +15,3 @@ Please correct the problem or add an initial comment about the issue at: {{ h.ur
 Thank you,
 
 The {{ site_title }} team
-
---
-
-Issue: {{ h.url_for('issues.show_issue', dataset_id=dataset.name, issue_number=issue.number, qualified=True) }}
-Dataset: {{ h.url_for('dataset_read', id=dataset.name, qualified=True) }}
-User: {{ user.fullname or user.name }}

--- a/ckanext/issues/tests/logic/action/test_issue.py
+++ b/ckanext/issues/tests/logic/action/test_issue.py
@@ -1,4 +1,3 @@
-from bs4.builder import TreeBuilder
 import mock
 import pytest
 
@@ -11,9 +10,11 @@ from ckanext.issues.model import Issue, IssueComment
 from ckanext.issues.logic.action.action import _get_recipients
 from ckanext.issues.tests.fixtures import issues_setup, user
 
+
 @pytest.fixture
 def dataset():
     return factories.Dataset()
+
 
 class TestIssueShow(object):
     @pytest.fixture
@@ -50,17 +51,13 @@ class TestIssueShow(object):
         )
         user_id = issue['user_id']
         user = model.Session.query(model.User).\
-            filter(model.User.id==user_id).first()
+            filter(model.User.id == user_id).first()
         user = vars(user)
         assert 'test.ckan.net' == user['name']
 
-class TestIssueNewWithEmailing(object):
-    @pytest.fixture
-    def config(self, ckan_config):
-        ckan_config['ckanext.issues.send_email_notifications'] = 'True'
-        return ckan_config
 
-    @pytest.mark.usefixtures("clean_db", "issues_setup", "config")
+class TestIssueNew(object):
+    @pytest.mark.usefixtures("clean_db", "issues_setup")
     def test_issue_create(self):
         creator = factories.User(name='creator')
         admin = factories.User(name='admin')
@@ -81,11 +78,6 @@ class TestIssueNewWithEmailing(object):
         assert 'Title' == issue_object.title
         assert 'Description' == issue_object.description
         assert 1 == issue_object.number
-        # some test user for the org called 'test.ckan.net' gets emailed too
-        # users_emailed = [call for call in render_mock.call_args]
-        # print(users_emailed)
-        # users_emailed = users_emailed[1]['extra_vars']['recipient']['user_id']
-        # assert admin['id'] in users_emailed
 
     @pytest.mark.usefixtures("clean_db", "issues_setup")
     def test_issue_create_second(self, user, dataset):
@@ -207,14 +199,6 @@ class TestIssueNewWithEmailing(object):
 
 
 class TestIssueComment(object):
-    @classmethod
-    def _apply_config_changes(cls, cfg):
-        # Mock out the emailer
-        from ckan.lib import mailer
-        cls.mock_mailer = mock.MagicMock()
-        mailer.mail_user = cls.mock_mailer
-        cfg['ckanext.issues.send_email_notifications'] = True
-
     @pytest.mark.usefixtures("clean_db", "issues_setup")
     def test_create_comment_on_issue(self):
         creator = factories.User(name='creator')
@@ -245,10 +229,6 @@ class TestIssueComment(object):
         assert len(comments) == 1
         assert comments[0]['comment'] == 'some comment'
         assert comments[0]['user']['name'] == 'commenter'
-        # some test user for the org called 'test.ckan.net' gets emailed too
-        # users_emailed = [call[1]['extra_vars']['recipient']['user_id']
-        #                  for call in render_mock.call_args_list]
-        # assert admin['id'] == users_emailed
 
     @pytest.mark.usefixtures("clean_db", "issues_setup")
     def test_create_comment_on_closed_issue(self, user, dataset):
@@ -312,8 +292,7 @@ class TestIssueSearch(object):
                                          dataset_id=dataset['id'],
                                          sort='oldest')
         issues_list = search_res['results']
-        assert [i['id'] for i in created_issues] == \
-             [i['id'] for i in issues_list]
+        assert [i['id'] for i in created_issues] == [i['id'] for i in issues_list]
         assert search_res['count'] == 10
 
     @pytest.mark.usefixtures("clean_db", "issues_setup")
@@ -340,8 +319,7 @@ class TestIssueSearch(object):
         issues_list = helpers.call_action('issue_search',
                                           context={'user': user['name']},
                                           sort='oldest')['results']
-        assert [i['id'] for i in created_issues] == \
-            [i['id'] for i in issues_list]
+        assert [i['id'] for i in created_issues] == [i['id'] for i in issues_list]
 
     @pytest.mark.usefixtures("clean_db", "issues_setup")
     def test_limit(self, user, dataset):
@@ -357,8 +335,7 @@ class TestIssueSearch(object):
             limit=5
         )
         issues_list = search_res['results']
-        assert [i['id'] for i in created_issues][:5] ==\
-             [i['id'] for i in issues_list]
+        assert [i['id'] for i in created_issues][:5] == [i['id'] for i in issues_list]
         assert search_res['count'] == 5
 
     @pytest.mark.usefixtures("clean_db", "issues_setup")
@@ -372,8 +349,7 @@ class TestIssueSearch(object):
                                           dataset_id=dataset['id'],
                                           sort='oldest',
                                           offset=5)['results']
-        assert [i['id'] for i in created_issues][5:] == \
-                      [i['id'] for i in issues_list]
+        assert [i['id'] for i in created_issues][5:] == [i['id'] for i in issues_list]
 
     @pytest.mark.usefixtures("clean_db", "issues_setup")
     def test_pagination(self, user, dataset):
@@ -387,8 +363,7 @@ class TestIssueSearch(object):
                                           sort='oldest',
                                           offset=5,
                                           limit=3)['results']
-        assert [i['id'] for i in created_issues][5:8] == \
-                      [i['id'] for i in issues_list]
+        assert [i['id'] for i in created_issues][5:8] == [i['id'] for i in issues_list]
 
     @pytest.mark.usefixtures("clean_db", "issues_setup")
     def test_filter_newest(self, user, dataset):
@@ -403,8 +378,7 @@ class TestIssueSearch(object):
                                           context={'user': user['name']},
                                           dataset_id=dataset['id'],
                                           sort='newest')['results']
-        assert list(reversed([i['id'] for i in issues])) == \
-                      [i['id'] for i in issues_list]
+        assert list(reversed([i['id'] for i in issues])) == [i['id'] for i in issues_list]
 
     @pytest.mark.usefixtures("clean_db", "issues_setup")
     def test_filter_least_commented(self, user, dataset):
@@ -473,8 +447,7 @@ class TestIssueSearch(object):
                                               q='title')['results']
 
         expected_issue_ids = set([i['id'] for i in issues[:2]])
-        assert expected_issue_ids ==\
-                set([i['id'] for i in filtered_issues])
+        assert expected_issue_ids == set([i['id'] for i in filtered_issues])
 
 
 class TestIssueUpdate(object):
@@ -571,6 +544,7 @@ class TestIssueUpdate(object):
             dataset_id=dataset['id'],
             issue_number=10000000,
         )
+
     @pytest.mark.usefixtures("clean_db", "issues_setup")
     def test_updating_issue_nonexisting_dataset_raises_not_found(self, user):
         pytest.raises(
@@ -637,8 +611,7 @@ class TestOrganizationUsersAutocomplete(object):
         result = helpers.call_action('organization_users_autocomplete',
                                      q='test',
                                      organization_id=organization['id'])
-        assert set(['test_owner', 'test_editor', 'test_admin']) ==\
-                    set([i['name'] for i in result])
+        assert set(['test_owner', 'test_editor', 'test_admin']) == set([i['name'] for i in result])
 
 
 class TestCommentSearch(object):
@@ -702,31 +675,27 @@ class TestCommentSearch(object):
                                      organization_id=organization['id'],
                                      only_hidden=True)
 
-        assert [comment1['id']] ==\
-                      [c['id'] for c in result]
+        assert [comment1['id']] == [c['id'] for c in result]
 
     @pytest.mark.usefixtures("clean_db", "issues_setup")
     def test_reported_search(self, comment1, comment3):
-        result = helpers.call_action('issue_comment_search',
-                                     only_hidden=True)
-
-        assert [comment1['id'], comment3['id']] ==\
-                      [c['id'] for c in result]
+        result = helpers.call_action(
+            'issue_comment_search', only_hidden=True
+            )
+        ids = [comment1['id'], comment3['id']]
+        assert ids == [c['id'] for c in result]
 
     @pytest.mark.usefixtures("clean_db", "issues_setup")
-    def test_search_for_org(self,organization, comment1, comment2):
+    def test_search_for_org(self, organization, comment1, comment2):
         result = helpers.call_action('issue_comment_search',
                                      organization_id=organization['id'])
 
-        assert [comment1['id'], comment2['id']] ==\
-                      [c['id'] for c in result]
+        assert [comment1['id'], comment2['id']] == [c['id'] for c in result]
 
     @pytest.mark.usefixtures("clean_db", "issues_setup")
     def test_search(self, comment1, comment2, comment3, comment4):
         result = helpers.call_action('issue_comment_search')
 
-        assert[comment1['id'],
-                comment2['id'],
-                comment3['id'],
-                comment4['id']] ==\
-                [c['id'] for c in result]
+        ids = [comment1['id'], comment2['id'], comment3['id'], comment4['id']]
+
+        assert ids == [c['id'] for c in result]

--- a/ckanext/issues/tests/logic/action/test_issue.py
+++ b/ckanext/issues/tests/logic/action/test_issue.py
@@ -8,7 +8,6 @@ from ckan.plugins import toolkit
 from ckanext.issues.tests import factories as issue_factories
 from ckanext.issues.model import Issue, IssueComment
 from ckanext.issues.logic.action.action import _get_recipients
-from ckanext.issues.tests.fixtures import issues_setup, user
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+pytest_plugins = ["ckanext.issues.tests.fixtures"]


### PR DESCRIPTION
This PR fixes an issue in which the `user_obj` was being overwritten in the recipients for loop causing the email body to not contain the correct user who wrote the comment.

It also adds some small changes to the template and a new TestEmailNotification test class.